### PR TITLE
Feat: Add file size validation to Media entity with Symfony constraints

### DIFF
--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use App\Repository\MediaRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: MediaRepository::class)]
 class Media
@@ -26,6 +27,9 @@ class Media
     #[ORM\Column]
     private string $title;
 
+    #[Assert\Image(
+        maxSize: '2M'
+    )]
     private ?UploadedFile $file = null;
 
     public function getId(): ?int


### PR DESCRIPTION
## Résumé

Ajoute une validation Symfony sur le fichier image associé à l’entité `Media`, afin de limiter la taille des uploads et de s’assurer qu’il s’agit bien d’une image. 

## Changements principaux

- **Entité `Media`** : import des contraintes Validator et annotation `#[Assert\Image(maxSize: '2M')]` sur la propriété non mappée `file` (`UploadedFile`), cohérente avec le formulaire `MediaType` (`data_class` = `Media`).

## À vérifier avant merge

- [x] Soumettre le formulaire média avec une image &lt; 2 Mo : création / enregistrement OK.
- [x] Soumettre avec un fichier &gt; 2 Mo ou non-image : erreur de validation affichée côté formulaire (message compréhensible).
- [x] Confirmer que le plafond **2 Mo** correspond au besoin métier (ajustement éventuel de la valeur).