### PR TITLE
Fix: Restrict access to admin media route and adjust media form fields

### DIFF
--- a/.cursor/rules/pr-description.mdc
+++ b/.cursor/rules/pr-description.mdc
@@ -1,0 +1,38 @@
+---
+description: Format des descriptions de Pull Request quand l’utilisateur en demande une (PR vers dev, résumé de branche, etc.)
+alwaysApply: true
+---
+
+# Descriptions de Pull Request
+
+Quand l’utilisateur demande une **description de PR**, un **résumé pour une merge request**, ou l’équivalent (souvent branche courante → `dev` ou autre base) :
+
+1. **Analyser le dépôt** : comparer la branche à la base cible (`git log` / `git diff` si nécessaire) pour que le contenu soit factuel.
+2. **Langue** : rédiger en **français**.
+3. **Livrable** : une **seule réponse** constituée d’un **bloc Markdown fenced** (triple backticks + `markdown`) **prêt à copier-coller** dans GitHub/GitLab — pas de texte hors du bloc sauf une phrase d’introduction minimale si utile.
+4. **Ton du texte** : **ne pas** utiliser de méta-formulations du type « cette PR », « cette merge request », ni mentionner explicitement la base de comparaison (ex. « par rapport à `dev` », « base : … »). Rester sur une **description factuelle** des changements et du périmètre, comme si le lecteur voyait déjà le contexte Git.
+
+## Structure obligatoire du bloc
+
+Le bloc doit suivre exactement cette ossature (adapter le contenu aux changements réels ; la checklist doit refléter les risques de la PR) :
+
+```markdown
+## Résumé
+
+(Une à trois phrases : objectif des changements et périmètre, sans méta-référence à la PR ni à la branche de base.)
+
+## Changements principaux
+
+- **Zone / thème** : ce qui a été fait (puces concises, regroupées par domaine technique ou fonctionnel).
+
+## À vérifier avant merge
+
+- [ ] Point actionnable lié aux migrations, config, tests, déploiement, etc.
+- [ ] …
+```
+
+## Style
+
+- **Succinct** : pas de roman ; privilégier des puces claires.
+- **Pas de section “Commits”** sauf demande explicite.
+- Si la base n’est pas précisée pour l’analyse Git, **supposer `dev`** — **sans** le citer dans le texte livré (voir point 4 ci-dessus).

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -25,6 +25,7 @@ security:
     access_control:
         - { path: ^/login$, roles: PUBLIC_ACCESS }
         - { path: ^/logout$, roles: PUBLIC_ACCESS }
+        - { path: ^/admin/media, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -18,8 +18,12 @@ security:
             lazy: true
             provider: users
             form_login:
-                login_path: admin_login
-                check_path: admin_login
+                login_path: app_login
+                check_path: app_login
+            logout:
+                path: app_logout
+                target: app_login
+
     role_hierarchy:
         ROLE_ADMIN: ROLE_USER
     access_control:

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -5,3 +5,7 @@ controllers:
 kernel:
   resource: ../src/Kernel.php
   type: attribute
+
+app_logout:
+  path: /logout
+  methods: [GET, POST]

--- a/src/Controller/Admin/SecurityController.php
+++ b/src/Controller/Admin/SecurityController.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
-    #[Route('/login', name: 'admin_login')]
+    #[Route('/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         $error = $authenticationUtils->getLastAuthenticationError();

--- a/templates/admin/login.html.twig
+++ b/templates/admin/login.html.twig
@@ -18,7 +18,7 @@
                         <div class="alert alert-danger" role="alert">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
                     {% endif %}
 
-                    <form action="{{ path('admin_login') }}" method="post">
+                    <form action="{{ path('app_login') }}" method="post">
                         <div class="mb-3">
                             <label for="username" class="form-label">Email:</label>
                             <input type="text" class="form-control" id="username" name="_username" value="{{ last_username }}" required>

--- a/templates/admin/media/add.html.twig
+++ b/templates/admin/media/add.html.twig
@@ -6,10 +6,10 @@
         <a href="{{ path('admin_media_index') }}" class="btn btn-primary">Retour</a>
     </div>
     {{ form_start(form) }}
-        {{ form_row(form.user) }}
+    {{ form_row(form.title) }}
         {% if is_granted('ROLE_ADMIN') %}
+            {{ form_row(form.user) }}
             {{ form_row(form.album) }}
-            {{ form_row(form.title) }}
         {% endif %}
         {{ form_row(form.file) }}
         <button type="submit" class="btn btn-primary">Ajouter</button>

--- a/templates/front.html.twig
+++ b/templates/front.html.twig
@@ -27,7 +27,7 @@
                             <a class="nav-link" href="{{ path('about') }}">Qui suis-je ?</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('admin_login') }}">Connexion</a>
+                            <a class="nav-link" href="{{ path('app_login') }}">Connexion</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Résumé

Contrôle d’accès aux routes d’administration des médias et formulaire d’ajout alignés : les utilisateurs **authentifiés** accèdent à `/admin/media` sans `ROLE_ADMIN`, avec un formulaire où le titre et le fichier sont pour tous et l’attribution utilisateur / album réservées aux admins.

## Changements principaux

- **Sécurité (Symfony)** : règle `access_control` pour `^/admin/media` avec `IS_AUTHENTICATED_FULLY`, placée avant `^/admin` (`ROLE_ADMIN`), pour dissocier le périmètre media du reste de l’admin.
- **Interface admin média** : dans `templates/admin/media/add.html.twig`, titre toujours affiché ; champs `user` et `album` uniquement si `ROLE_ADMIN` ; newline en fin de fichier.

## À vérifier avant merge

- [x] Parcours **utilisateur connecté sans rôle admin** : ajout / liste médias, formulaire (titre + fichier) sans erreur.
- [x] Parcours **admin** : champs utilisateur et album toujours disponibles et fonctionnels.
- [x] Aucune autre URL sous `/admin` (hors media) n’est accessible aux non-admins par effet de bord.
- [x] Accès **anonyme** à `/admin/media` : comportement attendu (refus / redirection).