### PR TITLE
Feat: Add user access control with on Users

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -17,6 +17,7 @@ security:
         main:
             lazy: true
             provider: users
+            user_checker: App\Security\UserAccessChecker
             form_login:
                 login_path: app_login
                 check_path: app_login

--- a/src/Controller/Admin/SecurityController.php
+++ b/src/Controller/Admin/SecurityController.php
@@ -5,15 +5,25 @@ namespace App\Controller\Admin;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SecurityController extends AbstractController
 {
     #[Route('/login', name: 'app_login')]
-    public function login(AuthenticationUtils $authenticationUtils): Response
+    public function login(AuthenticationUtils $authenticationUtils, TranslatorInterface $translator): Response
     {
         $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
+
+        if ($error instanceof CustomUserMessageAccountStatusException) {
+            $this->addFlash(
+                'danger',
+                $translator->trans($error->getMessageKey(), $error->getMessageData(), 'security')
+            );
+            $error = null;
+        }
 
         return $this->render('admin/login.html.twig', [
             'last_username' => $lastUsername,

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -22,7 +22,7 @@ class HomeController extends AbstractController
     #[Route('/guests', name: 'guests')]
     public function guests(UserRepository $userRepository)
     {
-        $guests = $userRepository->findBy(['admin' => false]);
+        $guests = $userRepository->findBy(['admin' => false, 'hasAccess' => true]);
         return $this->render('front/guests.html.twig', [
             'guests' => $guests
         ]);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -44,6 +44,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column]
     private array $roles = [];
 
+    #[ORM\Column(options: ['default' => true])]
+    private bool $hasAccess = true;
+
     public function __construct()
     {
         $this->medias = new ArrayCollection();
@@ -145,5 +148,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function getUserIdentifier(): string
     {
         return (string) $this->email;
+    }
+
+    public function hasAccess(): ?bool
+    {
+        return $this->hasAccess;
+    }
+
+    public function setHasAccess(bool $hasAccess): static
+    {
+        $this->hasAccess = $hasAccess;
+
+        return $this;
     }
 }

--- a/src/Migrations/Version20260408074130.php
+++ b/src/Migrations/Version20260408074130.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260408074130 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user ADD has_access TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE `user` DROP has_access');
+    }
+}

--- a/src/Security/UserAccessChecker.php
+++ b/src/Security/UserAccessChecker.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserAccessChecker implements UserCheckerInterface
+{
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if (!$user instanceof User){
+            return;
+        }
+
+        if (!$user->hasAccess()) {
+            throw new CustomUserMessageAccountStatusException('Ce compte a été désactivé. Vous n\'avez plus accès.');
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function checkPostAuth(UserInterface $user): void
+    {
+        if (!$user instanceof User){
+            return;
+        }
+    }
+}

--- a/templates/admin/login.html.twig
+++ b/templates/admin/login.html.twig
@@ -14,6 +14,9 @@
             <nav class="col-md-6 col-lg-4">
                 <div class="position-sticky">
                     <h1 class="text-white">Connexion</h1>
+                    {% for message in app.flashes('danger') %}
+                        <div class="alert alert-danger" role="alert">{{ message }}</div>
+                    {% endfor %}
                     {% if error %}
                         <div class="alert alert-danger" role="alert">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
                     {% endif %}


### PR DESCRIPTION
## Résumé

Introduction d’un droit d’accès par compte utilisateur (`hasAccess`) : les comptes désactivés ne peuvent plus se connecter à l’administration, et seuls les invités autorisés apparaissent sur la page publique des invités.

## Changements principaux

- **Données** : nouveau champ booléen sur l’entité `User`, migré en base (`has_access`), valeur par défaut true côté entité.
- **Sécurité** : `UserAccessChecker` branché sur le firewall `main` ; avant authentification, refus avec message explicite si `hasAccess` est faux.
- **Connexion admin** : gestion des erreurs de statut de compte via message flash traduit et affichage des alertes `danger` sur le formulaire de login.
- **Front** : la route `/guests` ne liste plus que les utilisateurs non admin **et** `hasAccess` à true.

## À vérifier avant merge

- [x] Exécuter les migrations Doctrine en environnement cible ; confirmer que la colonne `has_access` s’applique correctement aux lignes existantes (ajout `NOT NULL` sans défaut SQL explicite).
- [x] Vérifier le flux de login : compte avec `hasAccess` à false → message utilisateur attendu, pas d’accès admin.
- [x] Vérifier que la liste publique des invités reflète bien la politique métier (comptes sans accès exclus).