### PR TITLE
Feat: admin guest crud implementation

### DIFF
--- a/.cursor/rules/issue-description.mdc
+++ b/.cursor/rules/issue-description.mdc
@@ -1,0 +1,56 @@
+---
+description: Format des descriptions d’issue / ticket quand l’utilisateur en demande une
+alwaysApply: true
+---
+
+# Descriptions d’issue
+
+Quand l’utilisateur demande une **description d’issue**, un **ticket**, une **spécification pour GitHub/GitLab/Jira**, ou l’équivalent :
+
+1. **Analyser le dépôt** si nécessaire (`git`, recherche dans le code) pour que le contenu soit **factuel** (fichiers, patterns existants, conventions).
+2. **Langue** : rédiger en **français**.
+3. **Livrable** : une **seule réponse** constituée d’un **bloc Markdown fenced** ouvrant par ` ```markdown ` et fermant par ` ``` `, **prêt à copier-coller** — pas de texte hors du bloc sauf une phrase d’introduction **minimale** si utile.
+4. **Ton** : description **factuelle** du besoin et du périmètre ; éviter les formulations vagues (« il faudrait penser à… ») au profit de critères vérifiables.
+
+## Structure obligatoire du bloc
+
+Le bloc doit suivre cette ossature (adapter les sections au sujet ; retirer ou fusionner des sections si le ticket est minuscule) :
+
+```markdown
+## Titre
+
+**…**
+
+## Contexte
+
+…
+
+## Objectif
+
+…
+
+## Périmètre fonctionnel
+
+- …
+
+## Sécurité et règles métier
+
+(ou « Contraintes techniques » — uniquement si pertinent.)
+
+- …
+
+## Critères d’acceptation
+
+- [ ] …
+- [ ] …
+
+## Hors périmètre
+
+(« À trancher si besoin » — optionnel.)
+```
+
+## Style
+
+- **Succinct** : puces claires, pas de roman.
+- Les **titres de sections** (`## …`) dans le bloc livré doivent rester ceux du gabarit ci-dessus (contenu à adapter, pas la structure de titres sauf demande contraire).
+- Si l’utilisateur impose un gabarit ou un outil (Jira, template interne), **prioriser sa demande** tout en conservant le livrable en **un seul bloc** `markdown` copiable.

--- a/src/Controller/Admin/GuestController.php
+++ b/src/Controller/Admin/GuestController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\User;
+use App\Form\AdminGuestType;
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+class GuestController extends AbstractController
+{
+    /**
+     * Suppression d’un invité : les Media liés sont supprimés en cascade (entités + fichiers sur disque),
+     * conformément au périmètre produit (confirmation côté client avant l’appel DELETE).
+     */
+    #[Route('/admin/guest', name: 'admin_guest_index')]
+    public function index(UserRepository $userRepository): Response
+    {
+        $guests = $userRepository->findBy(['admin' => false], ['email' => 'ASC']);
+
+        return $this->render('admin/guest/index.html.twig', [
+            'guests' => $guests,
+        ]);
+    }
+
+    #[Route('/admin/guest/add', name: 'admin_guest_add')]
+    public function add(
+        Request $request,
+        EntityManagerInterface $entityManager,
+        UserPasswordHasherInterface $passwordHasher,
+    ): Response {
+        $guest = new User();
+        $form = $this->createForm(AdminGuestType::class, $guest);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $guest->setAdmin(false);
+                $guest->setRoles([]);
+                $plain = (string) $form->get('plainPassword')->getData();
+                $guest->setPassword($passwordHasher->hashPassword($guest, $plain));
+                $entityManager->persist($guest);
+                $entityManager->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('danger', 'Un compte avec cet email existe déjà.');
+
+                return $this->render('admin/guest/add.html.twig', [
+                    'form' => $form->createView(),
+                ]);
+            }
+
+            $this->addFlash('success', 'Invité créé.');
+
+            return $this->redirectToRoute('admin_guest_index');
+        }
+
+        return $this->render('admin/guest/add.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/admin/guest/update/{id}', name: 'admin_guest_update')]
+    public function update(
+        Request $request,
+        int $id,
+        UserRepository $userRepository,
+        EntityManagerInterface $entityManager,
+        UserPasswordHasherInterface $passwordHasher,
+    ): Response {
+        $guest = $this->getGuestOr404($id, $userRepository);
+        $form = $this->createForm(AdminGuestType::class, $guest);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $guest->setAdmin(false);
+                $guest->setRoles([]);
+                $plain = $form->get('plainPassword')->getData();
+                if (\is_string($plain) && $plain !== '') {
+                    $guest->setPassword($passwordHasher->hashPassword($guest, $plain));
+                }
+                $entityManager->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('danger', 'Un compte avec cet email existe déjà.');
+
+                return $this->render('admin/guest/update.html.twig', [
+                    'form' => $form->createView(),
+                ]);
+            }
+
+            $this->addFlash('success', 'Invité modifié.');
+
+            return $this->redirectToRoute('admin_guest_index');
+        }
+
+        return $this->render('admin/guest/update.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/admin/guest/delete/{id}', name: 'admin_guest_delete')]
+    public function delete(int $id, UserRepository $userRepository, EntityManagerInterface $entityManager): Response
+    {
+        $guest = $this->getGuestOr404($id, $userRepository);
+
+        $paths = [];
+        foreach ($guest->getMedias()->toArray() as $media) {
+            $paths[] = $media->getPath();
+            $entityManager->remove($media);
+        }
+
+        $mediaCount = \count($paths);
+        $entityManager->remove($guest);
+        $entityManager->flush();
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        if ($mediaCount > 0) {
+            $this->addFlash('success', sprintf(
+                'Invité supprimé. %d média(s) associé(s) ont également été supprimé(s).',
+                $mediaCount,
+            ));
+        } else {
+            $this->addFlash('success', 'Invité supprimé.');
+        }
+
+        return $this->redirectToRoute('admin_guest_index');
+    }
+
+    private function getGuestOr404(int $id, UserRepository $userRepository): User
+    {
+        $user = $userRepository->find($id);
+        if (!$user instanceof User || $user->isAdmin()) {
+            throw $this->createNotFoundException();
+        }
+
+        return $user;
+    }
+}

--- a/src/Controller/Admin/MediaController.php
+++ b/src/Controller/Admin/MediaController.php
@@ -12,6 +12,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class MediaController extends AbstractController
 {
+    #[Route('/admin', name: 'admin_index')]
     #[Route('/admin/media', name: 'admin_media_index')]
     public function index(Request $request, MediaRepository $mediaRepository)
     {

--- a/src/Form/AdminGuestType.php
+++ b/src/Form/AdminGuestType.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class AdminGuestType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class, [
+                'label' => 'Email (identifiant de connexion)',
+            ])
+            ->add('name', TextType::class, [
+                'label' => 'Nom',
+                'required' => false,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'Description',
+                'required' => false,
+                'attr' => ['rows' => 6],
+            ])
+            ->add('hasAccess', CheckboxType::class, [
+                'label' => 'Accès actif',
+                'required' => false,
+            ])
+            ->add('plainPassword', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'mapped' => false,
+                'required' => false,
+                'first_options' => [
+                    'label' => 'Mot de passe',
+                    'attr' => ['autocomplete' => 'new-password'],
+                    'constraints' => [
+                        new NotBlank(message: 'Saisissez un mot de passe.', groups: ['creation']),
+                        new Length(min: 6, max: 4096),
+                    ],
+                ],
+                'second_options' => [
+                    'label' => 'Répéter le mot de passe',
+                    'attr' => ['autocomplete' => 'new-password'],
+                ],
+                'invalid_message' => 'Les mots de passe ne correspondent pas.',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+            'validation_groups' => function (FormInterface $form) {
+                $data = $form->getData();
+                if ($data instanceof User && $data->getId()) {
+                    return ['Default'];
+                }
+
+                return ['Default', 'creation'];
+            },
+        ]);
+    }
+}

--- a/templates/admin.html.twig
+++ b/templates/admin.html.twig
@@ -19,7 +19,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="">
+                                <a class="nav-link" href="{{ path('admin_guest_index') }}">
                                     Invités
                                 </a>
                             </li>

--- a/templates/admin/guest/add.html.twig
+++ b/templates/admin/guest/add.html.twig
@@ -1,0 +1,22 @@
+{% extends 'admin.html.twig' %}
+
+{% block admin %}
+    {% for label, messages in app.flashes %}
+        {% for message in messages %}
+            <div class="alert alert-{{ label == 'error' ? 'danger' : label }}" role="alert">{{ message }}</div>
+        {% endfor %}
+    {% endfor %}
+
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>Invités</h1>
+        <a href="{{ path('admin_guest_index') }}" class="btn btn-primary">Retour</a>
+    </div>
+    {{ form_start(form) }}
+    {{ form_row(form.email) }}
+    {{ form_row(form.plainPassword) }}
+    {{ form_row(form.name) }}
+    {{ form_row(form.description) }}
+    {{ form_row(form.hasAccess) }}
+    <button type="submit" class="btn btn-primary">Ajouter</button>
+    {{ form_end(form) }}
+{% endblock %}

--- a/templates/admin/guest/index.html.twig
+++ b/templates/admin/guest/index.html.twig
@@ -1,0 +1,47 @@
+{% extends 'admin.html.twig' %}
+
+{% block admin %}
+    {% for label, messages in app.flashes %}
+        {% for message in messages %}
+            <div class="alert alert-{{ label == 'error' ? 'danger' : label }}" role="alert">{{ message }}</div>
+        {% endfor %}
+    {% endfor %}
+
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>Invités</h1>
+        <a href="{{ path('admin_guest_add') }}" class="btn btn-primary">Ajouter</a>
+    </div>
+    <table class="table">
+        <thead>
+        <tr>
+            <th>Email</th>
+            <th>Nom</th>
+            <th>Accès actif</th>
+            <th>Médias</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for guest in guests %}
+            <tr>
+                <td>{{ guest.email }}</td>
+                <td>{{ guest.name ?? '—' }}</td>
+                <td>{{ guest.hasAccess ? 'Oui' : 'Non' }}</td>
+                <td>{{ guest.medias|length }}</td>
+                <td>
+                    <a href="{{ path('admin_guest_update', {id: guest.id}) }}" class="btn btn-warning">Modifier</a>
+                    <a href="{{ path('admin_guest_delete', {id: guest.id}) }}"
+                       class="btn btn-danger"
+                       onclick="return confirm({{ (
+                           guest.medias|length > 0
+                           ? 'Supprimer cet invité et ses ' ~ guest.medias|length ~ ' média(s) associé(s) ? Cette action est irréversible.'
+                           : 'Supprimer cet invité ?'
+                       )|json_encode|e('html_attr') }});">
+                        Supprimer
+                    </a>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/templates/admin/guest/update.html.twig
+++ b/templates/admin/guest/update.html.twig
@@ -1,0 +1,23 @@
+{% extends 'admin.html.twig' %}
+
+{% block admin %}
+    {% for label, messages in app.flashes %}
+        {% for message in messages %}
+            <div class="alert alert-{{ label == 'error' ? 'danger' : label }}" role="alert">{{ message }}</div>
+        {% endfor %}
+    {% endfor %}
+
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>Invités</h1>
+        <a href="{{ path('admin_guest_index') }}" class="btn btn-primary">Retour</a>
+    </div>
+    <p class="text-muted small">Laissez les champs mot de passe vides pour conserver le mot de passe actuel.</p>
+    {{ form_start(form) }}
+    {{ form_row(form.email) }}
+    {{ form_row(form.plainPassword) }}
+    {{ form_row(form.name) }}
+    {{ form_row(form.description) }}
+    {{ form_row(form.hasAccess) }}
+    <button type="submit" class="btn btn-primary">Modifier</button>
+    {{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
## Résumé

Mise en place de la gestion des invités côté administration : liste, création, modification et suppression des comptes utilisateurs non admin, avec saisie du mot de passe (hash Symfony) et gestion des doublons d’email. La suppression retire aussi les médias associés (entités + fichiers sur disque), avec confirmation navigateur. Un gabarit Cursor pour les descriptions d’issue est ajouté.

## Changements principaux

- **Admin / invités** : nouveau `GuestController` (routes `/admin/guest`, ajout, mise à jour, suppression) ; accès réservé aux admins via la règle `access_control` existante sur `^/admin`. Les opérations ciblent uniquement les utilisateurs avec `admin === false` (404 si introuvable ou compte admin).
- **Formulaire** : `AdminGuestType` (email, nom, description, accès actif, mot de passe en `RepeatedType` avec contraintes renforcées à la création ; mot de passe optionnel à l’édition pour conserver l’existant).
- **UX** : templates Twig (liste en tableau, formulaires, flashes) ; lien « Invités » dans `admin.html.twig` ; route nommée `admin_index` sur `/admin` dans `MediaController` (cohérence des entrées admin).
- **Outils Cursor** : règle `.cursor/rules/issue-description.mdc` (format des tickets / issues).

## À vérifier avant merge

- [x] Tester le parcours complet sur un environnement proche de la prod : création, édition avec/sans nouveau mot de passe, doublon d’email, suppression avec et sans médias (fichiers bien retirés du disque).
- [x] Valider le niveau de protection souhaité pour la suppression (lien GET + `confirm` uniquement : risque CSRF / bookmark / préchargement selon la politique sécurité du projet).
- [x] Vérifier qu’aucun conflit de route ou de nom (`admin_index`) n’apparaît avec d’autres contrôleurs ou liens existants.