### PR TITLE
Feat: Unit test implementation

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -24,10 +24,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private bool $admin = false;
 
     #[ORM\Column]
-    private ?string $name;
+    private ?string $name = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
-    private ?string $description;
+    private ?string $description = null;
 
     #[ORM\Column(length: 180, unique: true)]
     private ?string $email = null;

--- a/src/Security/UserAccessChecker.php
+++ b/src/Security/UserAccessChecker.php
@@ -3,6 +3,7 @@
 namespace App\Security;
 
 use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -23,7 +24,7 @@ class UserAccessChecker implements UserCheckerInterface
     /**
      * @inheritDoc
      */
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
         if (!$user instanceof User){
             return;

--- a/tests/Unit/Entity/AlbumTest.php
+++ b/tests/Unit/Entity/AlbumTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Album;
+use PHPUnit\Framework\TestCase;
+
+class AlbumTest extends TestCase
+{
+    public function testIsTrue(): void
+    {
+        $album = new Album();
+
+        $album->setName('test');
+
+        $this->assertTrue($album->getName() === 'test');
+        $this->assertTrue($album->getId() === null);
+    }
+
+    public function testIsFalse(): void
+    {
+        $album = new Album();
+
+        $album->setName('test');
+
+        $this->assertFalse($album->getName() === 'false');
+        $this->assertFalse($album->getId() === !null);
+    }
+
+    public function testIsEmpty(): void
+    {
+        $album = new Album();
+        $album->setName('');
+
+        $this->assertEmpty($album->getName());
+        $this->assertEmpty($album->getId());
+    }
+}

--- a/tests/Unit/Entity/MediaTest.php
+++ b/tests/Unit/Entity/MediaTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Album;
+use App\Entity\Media;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class MediaTest extends TestCase
+{
+    public function testIsTrue(): void
+    {
+        $media = new Media();
+        $user = new User();
+        $album = new Album();
+        $file = new UploadedFile('public/uploads/0001.jpg', 'test');
+
+        $media->setPath('public/uploads/0001.jpg');
+        $media->setTitle('test');
+        $media->setUser($user);
+        $media->setAlbum($album);
+        $media->setFile($file);
+
+        $this->assertTrue($media->getPath() === 'public/uploads/0001.jpg');
+        $this->assertTrue($media->getTitle() === 'test');
+        $this->assertTrue($media->getUser() === $user);
+        $this->assertTrue($media->getAlbum() === $album);
+        $this->assertTrue($media->getId() === null);
+        $this->assertTrue($media->getFile() === $file);
+    }
+
+    public function testIsFalse(): void
+    {
+        $media = new Media();
+        $user = new User();
+        $album = new Album();
+        $file = new UploadedFile('public/uploads/0001.jpg', 'test');
+
+        $media->setPath('public/uploads/0001.jpg');
+        $media->setTitle('test');
+        $media->setUser($user);
+        $media->setAlbum($album);
+        $media->setFile($file);
+
+        $this->assertFalse($media->getPath() === 'false');
+        $this->assertFalse($media->getTitle() === 'false');
+        $this->assertFalse($media->getUser() === new User());
+        $this->assertFalse($media->getAlbum() === new Album());
+        $this->assertFalse($media->getId() === !null);
+        $this->assertFalse($media->getFile() === new UploadedFile('public/uploads/0002.jpg', 'test'));
+    }
+
+    public function testIsEmpty(): void
+    {
+        $media = new Media();
+        $media->setPath('');
+        $media->setTitle('');
+
+        $this->assertEmpty($media->getPath());
+        $this->assertEmpty($media->getTitle());
+        $this->assertEmpty($media->getId());
+        $this->assertEmpty($media->getUser());
+        $this->assertEmpty($media->getAlbum());
+        $this->assertEmpty($media->getFile());
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Media;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testIsTrue(): void
+    {
+        $user = new User();
+        $media = new Media();
+        $collection = $user->getMedias();
+        $collection->add($media);
+
+        $user->setEmail('test@test.com');
+        $user->setPassword('test');
+        $user->setAdmin(true);
+        $user->setName('test');
+        $user->setRoles(['ROLE_ADMIN']);
+        $user->setDescription('test');
+        $user->setHasAccess(true);
+        $user->setMedias($collection);
+
+        $this->assertTrue($user->getEmail() === 'test@test.com');
+        $this->assertTrue($user->getPassword() === 'test');
+        $this->assertTrue($user->isAdmin());
+        $this->assertTrue($user->getName() === 'test');
+        $this->assertTrue($user->getRoles() === ['ROLE_ADMIN', 'ROLE_USER']);
+        $this->assertTrue($user->getDescription() === 'test');
+        $this->assertTrue($user->hasAccess());
+        $this->assertTrue($user->getMedias()->contains($media));
+        $this->assertTrue($user->getId() === null);
+        $this->assertTrue($user->getUserIdentifier() === 'test@test.com');
+    }
+
+    public function testIsFalse(): void
+    {
+        $user = new User();
+        $media = new Media();
+        $collection = $user->getMedias();
+        $collection->add($media);
+
+
+        $user->setEmail('test@test.com');
+        $user->setPassword('test');
+        $user->setAdmin(false);
+        $user->setName('test');
+        $user->setRoles([]);
+        $user->setDescription('test');
+        $user->setHasAccess(false);
+        $user->setMedias($collection);
+
+        $this->assertFalse($user->getEmail() === 'false');
+        $this->assertFalse($user->getPassword() === 'false');
+        $this->assertFalse($user->isAdmin());
+        $this->assertFalse($user->getName() === 'false');
+        $this->assertFalse($user->getRoles() === []);
+        $this->assertFalse($user->getDescription() === 'false');
+        $this->assertFalse($user->hasAccess());
+        $this->assertFalse($user->getMedias()->contains(new Media()));
+        $this->assertFalse($user->getId() === !null);
+        $this->assertFalse($user->getUserIdentifier() === 'false');
+    }
+
+    public function testIsEmpty(): void
+    {
+        $user = new User();
+
+        $this->assertEmpty($user->getEmail());
+        $this->assertEmpty($user->getPassword());
+        $this->assertEmpty($user->getName());
+        $this->assertEmpty($user->getDescription());
+        $this->assertEmpty($user->getMedias());
+        $this->assertEmpty($user->getId());
+        $this->assertEmpty($user->getUserIdentifier());
+    }
+}

--- a/tests/UserAccessCheckerTest.php
+++ b/tests/UserAccessCheckerTest.php
@@ -2,12 +2,50 @@
 
 namespace App\Tests;
 
+use App\Entity\User;
+use App\Security\UserAccessChecker;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserAccessCheckerTest extends TestCase
 {
-    public function testSomething(): void
+    public function testPreAuthForUserWithNoAccess(): void
     {
-        $this->assertTrue(true);
+        $user = new User;
+        $checker = new UserAccessChecker();
+
+        $user->setHasAccess(false);
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('Ce compte a été désactivé. Vous n\'avez plus accès.');
+        $checker->checkPreAuth($user);
+    }
+
+    public function testPreAuthForUserWithAccess(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        try {
+            $user = new User;
+            $checker = new UserAccessChecker();
+
+            $user->setHasAccess(true);
+            $checker->checkPreAuth($user);
+        } catch (\Exception $e) {
+            $this->fail('No exception expected. User should have access');
+        }
+    }
+
+    public function testWithNonUserUserInterface(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $user = $this->getMockBuilder(UserInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $checker = new UserAccessChecker();
+
+        $checker->checkPreAuth($user);
+        $checker->checkPostAuth($user);
     }
 }

--- a/tests/UserAccessCheckerTest.php
+++ b/tests/UserAccessCheckerTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class UserAccessCheckerTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
#10 

## Résumé

Renforcement de la couverture de tests sur les entités métier et sur le contrôle d’accès utilisateur, avec deux ajustements de code pour aligner l’API Symfony et stabiliser l’état initial des propriétés `User`.

## Changements principaux

- **Tests unitaires (entités)** : ajout de suites PHPUnit pour `Album`, `Media` et `User` (getters/setters, collections, rôles agrégés avec `ROLE_USER`, identifiant utilisateur, cas vides / négatifs).
- **Tests `UserAccessChecker`** : scénarios `checkPreAuth` avec et sans accès, message d’exception attendu pour un compte désactivé, et comportement neutre lorsque l’utilisateur n’est pas une instance `App\Entity\User` (mock `UserInterface`), couvrant aussi `checkPostAuth` dans ce cas.
- **Sécurité / Symfony** : signature de `checkPostAuth` étendue avec le paramètre optionnel `?TokenInterface $token = null` et import associé, conformément à l’interface `UserCheckerInterface`.
- **Entité `User`** : valeurs par défaut explicites `null` sur `name` et `description` pour éviter un état non initialisé lors de l’instanciation dans les tests (et en runtime).

## À vérifier avant merge

- [x] La suite de tests PHPUnit passe en CI et localement (`phpunit` / équivalent du projet).
- [x] Les tests `MediaTest` qui s’appuient sur `UploadedFile` et un chemin de fichier trouvent bien une ressource valide dans l’environnement d’exécution (fichier présent ou stratégie de fixture adaptée).
- [x] Aucune régression sur l’authentification : le `UserChecker` est toujours correctement invoqué avec la nouvelle signature côté version Symfony utilisée.
- [x] Comportement métier inchangé pour les utilisateurs existants (les défauts `null` sur `name` / `description` restent équivalents à l’absence de valeur en base).